### PR TITLE
Remove dynamodb scan limit. Add timestamp to stored reviews 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1222,6 +1222,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://nexus02.prod-int.sparebank1.no/repository/npmgroup/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://nexus.intern.sparebank1.no/nexus/content/groups/npmgroup/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "googleapis": "^39.2.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash.debounce": "^4.0.8",
-    "lodash.flatten": "^4.4.0"
+    "lodash.flatten": "^4.4.0",
+    "moment": "^2.29.1"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/src/db/dynamo-service.js
+++ b/src/db/dynamo-service.js
@@ -1,3 +1,4 @@
+const moment = require("moment");
 const AWS = require('aws-sdk');
 const { isProduction } = require('../utils/env-utils');
 
@@ -16,9 +17,7 @@ const client = new AWS.DynamoDB.DocumentClient();
 
 const getReviews = async tableName => {
   const params = {
-    TableName: tableName,
-    ScanIndexForward: 'false',
-    Limit: 500
+    TableName: tableName
   };
 
   try {
@@ -49,7 +48,8 @@ const putReviews = async (tableName, reviews) => {
         const reviewsParams = chunk.map(review => ({
           PutRequest: {
             Item: {
-              id: review.id
+              id: review.id,
+              timestamp: moment().valueOf()
             }
           }
         }));


### PR DESCRIPTION
Fra før henter vi det vi trodde var de 500 siste postede reviews fra DynamoDB. Det viser seg at det er tilfeldig hvilke 500 reviews som returneres, siden det ikke er satt opp noen ordentlig sortering i DynamoDB. IDene som brukes er tilsynelatende tilfeldige. Nå har vi gått over 500 reviews i android-tabellen, og da er det en sjanse for at noen reviews blir postet på nytt (avhengig om de blir inkludert i de 500 vi får fra Dynamo eller ikke). 

Denne endringen fjerner limit på 500 items fra DynamoDB. Det vil fortsatt være en implisitt limit på 1MB i responsen, men det er lenge til vi treffer den. Akkurat nå er hele databasen på 47 KB, så det er mye å gå på der. Men problemet kommer til å skje igjen. Derfor legger jeg inn timestamp på det vi lagrer i Dynamo, som vi kan bruke til å begrense settet senere. Det får skje i en egen PR. 