### PR TITLE
Update AWS Lambda Node runtime

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -36,7 +36,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/index.getAndPublishReviews
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of scheduled events.
       MemorySize: 128
       Timeout: 60
@@ -54,7 +54,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/index.getAndPublishReviews
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of scheduled events.
       MemorySize: 128
       Timeout: 60
@@ -72,7 +72,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/index.getAndPublishReviews
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of scheduled events.
       MemorySize: 128
       Timeout: 60


### PR DESCRIPTION
AWS Lambda slutter å støtte Node 10 runtime 30. juli. Oppdaterer til Node 14. 

Jeg har Node 14 lokalt, og koden kjører fint. Men vi får følge med i loggene :+1: 